### PR TITLE
BuildResponse: build_id property is unused

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -29,7 +29,6 @@ class BuildResponse(object):
         self._json = build_json
         self.request = request
         self._status = None
-        self._build_id = None
 
     @property
     def json(self):
@@ -48,12 +47,6 @@ class BuildResponse(object):
         cap_value = value.capitalize()
         logger.info("changing status from %s to %s", self.status, cap_value)
         self.json['status']['phase'] = cap_value
-
-    @property
-    def build_id(self):
-        if self._build_id is None:
-            self._build_id = self.json['metadata']['name']
-        return self._build_id
 
     def is_finished(self):
         return self.status in BUILD_FINISHED_STATES

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -130,7 +130,7 @@ def cmd_build(args, osbs):
         yum_repourls=osbs.build_conf.get_yum_repourls(),
         namespace=osbs.build_conf.get_namespace(),
     )
-    build_id = build.build_id
+    build_id = build.get_build_name()
     # we need to wait for kubelet to schedule the build, otherwise it's 500
     namespace = osbs.build_conf.get_namespace()
     build = osbs.wait_for_build_to_get_scheduled(build_id, namespace=namespace)


### PR DESCRIPTION
For identical functionality use get_build_name() method.